### PR TITLE
Cardflip Minigame Fixes

### DIFF
--- a/CampaignTrip/Assets/Minigames/Scripts/CardFlipManager.cs
+++ b/CampaignTrip/Assets/Minigames/Scripts/CardFlipManager.cs
@@ -39,6 +39,8 @@ public class CardFlipManager : MinigameManager
 		randomCards.Remove(winningCard);
 		winningCard.isWinner = true;
 
+		yield return new WaitForSecondsRealtime(.5f);//make sure everyones here
+
 		while (randomPlayersCopy.Count != 0)
 		{
 			PersistentPlayer p = randomPlayersCopy[0];

--- a/CampaignTrip/Assets/Minigames/Scripts/FlippableCard.cs
+++ b/CampaignTrip/Assets/Minigames/Scripts/FlippableCard.cs
@@ -13,7 +13,7 @@ public class FlippableCard : NetworkBehaviour
 	protected void OnMouseUpAsButton()
 	{
 		//the player who can flip them is the only one with authority to do so
-		if(hasAuthority)
+		if(hasAuthority && !MinigameManager.Instance.isGameOver)
 			CmdFlip();
 	}
 


### PR DESCRIPTION
-You can only flip one card now in the CardFlip Minigame
-fixes cards not flipping sometimes for the players who can see the loose cards